### PR TITLE
feat: Add share button to Capsule page using FontAwesome icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react-places-autocomplete": "^7.3.0",
         "react-router-dom": "^5.3.0",
         "react-scripts": "5.0.1",
+        "react-web-share": "^2.0.2",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -15848,6 +15849,16 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-web-share": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-web-share/-/react-web-share-2.0.2.tgz",
+      "integrity": "sha512-bGm1TJc6xtC0MhAnYFsrzT4En7l2oAdLTgCK7nk7b4xGTg3L5gOldiPrmYQ8a/dEXNydgekvOj/tfjduIlIRVA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-places-autocomplete": "^7.3.0",
     "react-router-dom": "^5.3.0",
     "react-scripts": "5.0.1",
+    "react-web-share": "^2.0.2",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/components/CapsuleBubble.jsx
+++ b/src/components/CapsuleBubble.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { RWebShare } from "react-web-share";
 import styles from '../styles/Capsule.module.css';
 import { useHistory } from 'react-router-dom';
 import GeminiMessages from './GeminiMessages';
@@ -119,6 +120,16 @@ const Capsule = ({ ...props }) => {
         <LikeButton capsuleId={id} likesCount={likesCount} setLikesCount={setLikesCount} />
         <p>{likesCount} {likesCount === 1 ? 'Like' : 'Likes'}</p>
       </div>
+      <RWebShare
+          data={{
+            text: message,
+            url: window.location.href,
+            title: title,
+          }}
+          onClick={() => console.log("shared successfully!")}
+        >
+          <i className={`${styles.ShareButton} fa-solid fa-share`}></i>
+        </RWebShare>
       <Comments capsuleId={id} /> {/* Add the Comments component here */}
       <div className="text-center">
         <Button

--- a/src/styles/Capsule.module.css
+++ b/src/styles/Capsule.module.css
@@ -51,9 +51,22 @@
 }
 
 .LikeButton {
-    color: red;
+    color: #ff0000;
 }
 
 .LikeButton:hover {
-    color: rgb(235, 0, 0);
+    color: #eb0000;
+}
+
+.ShareButton {
+    color: #808000;
+    cursor: pointer;
+    display: inline-flex;
+    float: right;
+    font-size: 2rem;
+    margin-top: -5rem;
+}
+
+.ShareButton:hover {
+    color: #636300;
 }


### PR DESCRIPTION
- Install react-web-share
- Add RWebShare component to enable web sharing functionality
- Replace the share button with a FontAwesome share icon
- Configure the share button to share the capsule's title, message, and URL
- Style the share icon for better visual appearance